### PR TITLE
Display help more liberally.

### DIFF
--- a/bin/plow
+++ b/bin/plow
@@ -24,7 +24,7 @@ declare -a commands
 
 if test $# = 0; then
   usage
-  exit
+  exit 0
 fi
 
 while test $# != 0; do
@@ -44,7 +44,7 @@ while test $# != 0; do
       ;;
     --help|usage|help)
       usage
-      exit
+      exit 0
       ;;
     --*)
       tmp=${1:2}

--- a/bin/plow
+++ b/bin/plow
@@ -24,7 +24,7 @@ declare -a commands
 
 if test $# = 0; then
   usage
-  exit 0
+  exit 64
 fi
 
 while test $# != 0; do

--- a/bin/plow
+++ b/bin/plow
@@ -22,6 +22,11 @@ function usage
 
 declare -a commands
 
+if test $# = 0; then
+  usage
+  exit
+fi
+
 while test $# != 0; do
   case "$1" in
     --staging|staging)
@@ -37,7 +42,7 @@ while test $# != 0; do
     --sudo|sudo)
       SUDO=sudo
       ;;
-    --help)
+    --help|usage|help)
       usage
       exit
       ;;

--- a/bin/plow
+++ b/bin/plow
@@ -24,7 +24,7 @@ declare -a commands
 
 if test $# = 0; then
   usage
-  exit 64
+  exit 64 # EX_USAGE - The command was used incorrectly
 fi
 
 while test $# != 0; do
@@ -44,7 +44,7 @@ while test $# != 0; do
       ;;
     --help|usage|help)
       usage
-      exit 0
+      exit
       ;;
     --*)
       tmp=${1:2}


### PR DESCRIPTION
Plow now displays help if you:
- don't enter any args or commands
- enter "help" or "usage"

It will continue to display help if you do:

```
plow --help
```
