### PR TITLE
Ignore any EC2 instances that are not running

### DIFF
--- a/bin/plow
+++ b/bin/plow
@@ -85,7 +85,7 @@ else
   INSTANCE_NAMES=($(echo "${DESCRIBE_TAG}" | grep TAG | awk {'print $3'}))
 
   for instance in ${INSTANCE_NAMES[@]}; do 
-    DESCRIBE_INSTANCE=$(ec2-describe-instances $instance)
+    DESCRIBE_INSTANCE=$(ec2-describe-instances --filter "instance-state-name=running" $instance)
     SERVERS[${#SERVERS[@]}]=$(echo ${DESCRIBE_INSTANCE} | sed -E 's/RESERVATION.*ami-.{9}//' | sed -E 's/\ .*//')
   done
 fi


### PR DESCRIPTION
Previously plow was attempting to run on terminated and stopped
instances.

This resolves issue https://github.com/mm53bar/plow/issues/9.
