### PR TITLE
Don't overwrite the .env.sample file if it exists

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -37,7 +37,7 @@
 # Downoad support files
 
       curl -s -L https://raw.github.com/mm53bar/plow/master/Plowfile -o Plowfile
-      curl -s -L https://raw.github.com/mm53bar/plow/master/.env.sample -o .env.sample
+      curl -s -L https://raw.github.com/mm53bar/plow/master/.env.sample >> .env.sample
 
 # Set the permissions for the scripts
 


### PR DESCRIPTION
Previously when you run install it overwrites the file that's already there. If I install this into an app directory that already has a .env.sample I lose all the sample env vars for that app.

Similar to PR in Pave: https://github.com/mm53bar/pave/pull/7
