### PR TITLE
Stop overwriting $USER

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # deploy to:
 SERVER=server.com
-USER=app_name
+DEPLOYER=app_name
 DEPLOY=/srv/$USER
 ENVIRONMENT=production
 

--- a/bin/plow
+++ b/bin/plow
@@ -120,5 +120,5 @@ fi
 mkdir -p .plow/files && cp ${FILES[@]} .plow/files/ && cd .plow
 for server in ${SERVERS[@]}; do
   echo -e "\033[1;35m== Plowing $server\033[0m"
-  tar cz . | ssh $SSH_USER@$server "rm -rf plow && mkdir plow && cd plow && tar xz && $SUDO bash plow.sh"
+  tar cz . | ssh $DEPLOYER@$server "rm -rf plow && mkdir plow && cd plow && tar xz && $SUDO bash plow.sh"
 done

--- a/bin/plow
+++ b/bin/plow
@@ -120,5 +120,5 @@ fi
 mkdir -p .plow/files && cp ${FILES[@]} .plow/files/ && cd .plow
 for server in ${SERVERS[@]}; do
   echo -e "\033[1;35m== Plowing $server\033[0m"
-  tar cz . | ssh $USER@$server "rm -rf plow && mkdir plow && cd plow && tar xz && $SUDO bash plow.sh"
+  tar cz . | ssh $SSH_USER@$server "rm -rf plow && mkdir plow && cd plow && tar xz && $SUDO bash plow.sh"
 done


### PR DESCRIPTION
It's evil to overwrite $USER in plow's .env file. Instead of using $USER, this commit updates plow to look for a $SSH_USER instead.

This is a BREAKING CHANGE.
