### PR TITLE
.env used during provisioning available to recipes.

### DIFF
--- a/bin/plow
+++ b/bin/plow
@@ -174,7 +174,11 @@ fi
 
 [[ $OVERRIDE_USER ]] && DEPLOYER=$OVERRIDE_USER
 
-[[ ${FILES[@]} ]] && mkdir -p .plow/files && cp ${FILES[@]} .plow/files/ && cd .plow
+mkdir -p .plow/files
+[[ ${FILES[@]} ]] && cp ${FILES[@]} .plow/files/
+cp $ENV_FILE .plow/env
+
+cd .plow
 for server in ${SERVERS[@]}; do
   echo -e "\033[1;35m== Plowing $server\033[0m"
   tar cz . | ssh -o ConnectTimeout=120 $DEPLOYER@$server "rm -rf plow && mkdir plow && cd plow && tar xz && $SUDO bash plow.sh"

--- a/bin/plow
+++ b/bin/plow
@@ -129,7 +129,7 @@ ENV_FILE=.env.$ENVIRONMENT
 [[ -f $ENV_FILE ]] || bail "no $ENV_FILE found"
 source $ENV_FILE
 
-mkdir -p .plow && cat $ENV_FILE > .plow/plow.sh
+mkdir -p .plow && echo "source ./env" > .plow/plow.sh
 
 for env_variable in "${env_variables[@]}"
 do

--- a/bin/plow
+++ b/bin/plow
@@ -129,7 +129,9 @@ ENV_FILE=.env.$ENVIRONMENT
 [[ -f $ENV_FILE ]] || bail "no $ENV_FILE found"
 source $ENV_FILE
 
-mkdir -p .plow && echo "source ./env" > .plow/plow.sh
+mkdir -p .plow && echo "
+# set environmental variables
+source ./env" > .plow/plow.sh
 
 for env_variable in "${env_variables[@]}"
 do


### PR DESCRIPTION
This is useful for tools like foreman and runit which can use them when configuring the environment for tools on the box. Otherwise this env file needs to be reconstructed by recipes on the server.

This was the only other change in our plow file when I updated from your latest. Hopefully this is the last push related to setting up sentinel.
