### PR TITLE
Make bail() available for use in recipes.

### DIFF
--- a/bin/plow
+++ b/bin/plow
@@ -131,7 +131,12 @@ source $ENV_FILE
 
 mkdir -p .plow && echo "
 # set environmental variables
-source ./env" > .plow/plow.sh
+source ./env
+
+bail() {
+  echo -e "\033[31m  failed: $1\033[0m"
+  exit 1
+}" > .plow/plow.sh
 
 for env_variable in "${env_variables[@]}"
 do


### PR DESCRIPTION
This provides a standard way for recipes to provide pave-style feedback to the user without needing to mimic the bail() function themselves.
