### PR TITLE
Warn and exit if a recipe doesn't exist

### DIFF
--- a/bin/plow
+++ b/bin/plow
@@ -123,7 +123,7 @@ done
 
 recipe() {
   if command -v wget > /dev/null; then
-    wget -nc -q -P .plow $1
+    wget -nc -q -P .plow $1 || bail "$1 recipe does not exist."
   else
     bail "wget not installed: brew install wget"
   fi


### PR DESCRIPTION
- If a recipe can't be fetched, fail with
  a warning
- Currently it fails (exit value of 8) without
  a warning, making it hard to find the issue
